### PR TITLE
Fixed elements count on page for pagination

### DIFF
--- a/lib/pagination.php
+++ b/lib/pagination.php
@@ -68,7 +68,7 @@ class Pagination implements PaginationInterface
         }
 
         if ($page === $countPages) {
-            return $totalCount % $limit;
+            return $totalCount - $limit * ($countPages-1);
         }
 
         return $totalCount > $limit ? $limit : $totalCount;


### PR DESCRIPTION
now works correctly when $totalCount is a multiple of $limit