### PR TITLE
FIx grid and fetchermodel

### DIFF
--- a/install/index.php
+++ b/install/index.php
@@ -14,8 +14,8 @@ class bx_model extends CModule
 
     public function __construct()
     {
-        $this->MODULE_VERSION = "1.24.3";
-        $this->MODULE_VERSION_DATE = "2021-11-17 12:00:00";
+        $this->MODULE_VERSION = "1.24.4";
+        $this->MODULE_VERSION_DATE = "2021-11-17 14:50:00";
         $this->MODULE_NAME = "Bitrix model";
         $this->MODULE_DESCRIPTION = "";
     }

--- a/install/index.php
+++ b/install/index.php
@@ -14,8 +14,8 @@ class bx_model extends CModule
 
     public function __construct()
     {
-        $this->MODULE_VERSION = "1.24.4";
-        $this->MODULE_VERSION_DATE = "2021-11-17 14:50:00";
+        $this->MODULE_VERSION = "1.24.5";
+        $this->MODULE_VERSION_DATE = "2021-11-17 16:00:00";
         $this->MODULE_NAME = "Bitrix model";
         $this->MODULE_DESCRIPTION = "";
     }

--- a/install/index.php
+++ b/install/index.php
@@ -1,4 +1,4 @@
-<?
+<?php
 
 IncludeModuleLangFile(__FILE__);
 use \Bitrix\Main\ModuleManager;
@@ -14,8 +14,8 @@ class bx_model extends CModule
 
     public function __construct()
     {
-        $this->MODULE_VERSION = "1.0.1";
-        $this->MODULE_VERSION_DATE = "2021-01-19 07:30:32";
+        $this->MODULE_VERSION = "1.24.3";
+        $this->MODULE_VERSION_DATE = "2021-11-17 12:00:00";
         $this->MODULE_NAME = "Bitrix model";
         $this->MODULE_DESCRIPTION = "";
     }

--- a/lib/fetchermodel.php
+++ b/lib/fetchermodel.php
@@ -277,16 +277,20 @@ class FetcherModel implements FetcherModelInterface
                 }
             }
 
-            if (!empty($class)) {
-                $resultCollection = new ModelCollection($resultList, $class);
-                if ($hasModifyCallback) {
-                    $resultCollection = ($this->modifyCallback)($resultCollection);
-                }
-
-                $model[$this->keySave] = !empty($this->classCast) ?
-                    $this->classCast::init($resultCollection) :
-                    $resultCollection;
+            if (empty($class)) {
+                $class = AbsOptimizedModel::class;
             }
+
+            $resultCollection = new ModelCollection($resultList, $class);
+            if ($hasModifyCallback) {
+                $resultCollection = ($this->modifyCallback)($resultCollection);
+            }
+
+            $model[$this->keySave] = !empty($this->classCast) ?
+                $this->classCast::init($resultCollection) :
+                $resultCollection;
+
+            unset($class);
         }
     }
 

--- a/lib/helper/extendeddate.php
+++ b/lib/helper/extendeddate.php
@@ -6,6 +6,9 @@ namespace Bx\Model\Helper;
 
 use Bitrix\Main\Type\Date;
 
+/**
+ * Заглушка для исправления бага в ядре битрикса с вызовом отсутствующего метода compile у Date
+ */
 class ExtendedDate extends Date
 {
     /**

--- a/lib/helper/extendeddatetime.php
+++ b/lib/helper/extendeddatetime.php
@@ -6,6 +6,9 @@ namespace Bx\Model\Helper;
 
 use Bitrix\Main\Type\DateTime;
 
+/**
+ * Заглушка для исправления бага в ядре битрикса с вызовом отсутствующего метода compile у DateTime
+ */
 class ExtendedDateTime extends DateTime
 {
     /**

--- a/lib/helper/filterparser.php
+++ b/lib/helper/filterparser.php
@@ -77,10 +77,10 @@ class FilterParser
         ] = static::parseFilterKey($key);
 
         if (static::isFilterDate($key)) {
-            $value = new ExtendedDate($value, 'Y-m-d');
+            $value = new ExtendedDate($value->format('Y-m-d'), 'Y-m-d');
             $key = str_replace('date_', '', $key);
         } elseif (static::isFilterDateTime($key)) {
-            $value = new ExtendedDateTime($value, 'Y-m-d\TH:i:s\Z');
+            $value = new ExtendedDateTime($value->format('Y-m-d\TH:i:s\Z'), 'Y-m-d\TH:i:s\Z');
             $key = str_replace('datetime_', '', $key);
         }
 

--- a/lib/helper/filterparser.php
+++ b/lib/helper/filterparser.php
@@ -2,6 +2,7 @@
 
 namespace Bx\Model\Helper;
 
+use Bitrix\Main\Type\Date;
 use Exception;
 use Psr\Http\Message\ServerRequestInterface;
 
@@ -76,12 +77,14 @@ class FilterParser
             $postValue
         ] = static::parseFilterKey($key);
 
-        if (static::isFilterDate($key)) {
-            $value = new ExtendedDate($value->format('Y-m-d'), 'Y-m-d');
-            $key = str_replace('date_', '', $key);
-        } elseif (static::isFilterDateTime($key)) {
-            $value = new ExtendedDateTime($value->format('Y-m-d\TH:i:s\Z'), 'Y-m-d\TH:i:s\Z');
-            $key = str_replace('datetime_', '', $key);
+        if ($value instanceof Date) {
+            if (static::isFilterDate($key)) {
+                $value = new ExtendedDate($value->format('Y-m-d'), 'Y-m-d');
+                $key = str_replace('date_', '', $key);
+            } elseif (static::isFilterDateTime($key)) {
+                $value = new ExtendedDateTime($value->format('Y-m-d\TH:i:s\Z'), 'Y-m-d\TH:i:s\Z');
+                $key = str_replace('datetime_', '', $key);
+            }
         }
 
         $isStrict = static::isStrictFilter($key);
@@ -160,7 +163,7 @@ class FilterParser
     {
         return [
             '%',
-           str_replace('like_', '', $key),
+            str_replace('like_', '', $key),
             ''
         ];
     }
@@ -174,7 +177,7 @@ class FilterParser
     {
         return [
             '',
-           str_replace('flike_', '', $key),
+            str_replace('flike_', '', $key),
             '%'
         ];
     }


### PR DESCRIPTION
Исправлены:
- Ошибка при фильтрации по дате в гриде из-за того, что $value, переданное в конструкторы дат, является экземпляром Date, а не строкой.
- null вместо пустой коллекции в fetchermodel при заполнении множественных связанных данных из пустого массива
- Название класса, передающееся из предыдущей итерации цикла при инициализации ModelCollection в fetchermodel
Tags:
1.24.3
fix(grid): fixed filtering by date or datetime
1.24.4
fix(fetchermodel): fixed empty classname and initialising modelcollection with invalid class
1.24.5
fix(grid): checking value in filter is instanceof date