### PR TITLE
fix(query): fixed count when group param is set

### DIFF
--- a/install/index.php
+++ b/install/index.php
@@ -14,8 +14,8 @@ class bx_model extends CModule
 
     public function __construct()
     {
-        $this->MODULE_VERSION = "1.25.1";
-        $this->MODULE_VERSION_DATE = "2021-11-23 10:30:00";
+        $this->MODULE_VERSION = "1.25.2";
+        $this->MODULE_VERSION_DATE = "2021-12-26 13:20:00";
         $this->MODULE_NAME = "Bitrix model";
         $this->MODULE_DESCRIPTION = "";
     }

--- a/lib/querymodel.php
+++ b/lib/querymodel.php
@@ -140,6 +140,10 @@ class QueryModel extends Query implements ModelQueryInterface
             $params['group'] = $this->group;
         }
 
+        if (!empty($this->select)) {
+            $params['select'] = $this->select;
+        }
+
         return $this->modelService->getCount($params, $this->userContext);
     }
 


### PR DESCRIPTION
Сейчас select не передаётся в параметры, соответственно выбираются все поля. В orm битрикса все поля из select попадают в group by ([дока](https://dev.1c-bitrix.ru/learning/course/index.php?COURSE_ID=43&LESSON_ID=5824&LESSON_PATH=3913.3516.5748.5824)), соответственно при указанном group количество будет считаться неправильно, ведь group будет заменяться на все поля из select.
Поэтому чтобы правильно считалось количество при указанной группировке, нужно в метод передавать в group и select одни и те же поля, а в самом методе должна быть поддержка передачи в параметрах указанного select.