### PR TITLE
fix(modelgrid): fixed error while using getlist before grid is shown and actions are processed

### DIFF
--- a/install/index.php
+++ b/install/index.php
@@ -14,8 +14,8 @@ class bx_model extends CModule
 
     public function __construct()
     {
-        $this->MODULE_VERSION = "1.25.2";
-        $this->MODULE_VERSION_DATE = "2021-12-26 13:20:00";
+        $this->MODULE_VERSION = "1.25.4";
+        $this->MODULE_VERSION_DATE = "2024-03-25 12:50:00";
         $this->MODULE_NAME = "Bitrix model";
         $this->MODULE_DESCRIPTION = "";
     }

--- a/lib/ui/admin/modelgrid.php
+++ b/lib/ui/admin/modelgrid.php
@@ -549,13 +549,17 @@ class ModelGrid
 
     private function preparePoxyModelService()
     {
-        $this->modelService->setSortFields($this->sortList);
-
-        $filterData = [];
-        foreach ($this->filterFields as $field) {
-            $filterData = array_merge($filterData, (array)$field->getFilterData());
+        if (!empty($this->sortList)) {
+            $this->modelService->setSortFields($this->sortList);
         }
-        $this->modelService->setFilterFields($filterData);
+
+        if (!empty($this->filterFields)) {
+            $filterData = [];
+            foreach ($this->filterFields as $field) {
+                $filterData = array_merge($filterData, (array)$field->getFilterData());
+            }
+            $this->modelService->setFilterFields($filterData);
+        }
     }
 
     /**

--- a/lib/ui/admin/modelgrid.php
+++ b/lib/ui/admin/modelgrid.php
@@ -526,7 +526,7 @@ class ModelGrid
         if ($this->collection instanceof ModelCollection) {
             return $this->collection;
         }
-
+        $this->preparePoxyModelService();
         return $this->collection = $this->getQuery()->getList();
     }
 
@@ -647,12 +647,14 @@ class ModelGrid
 
         $action = $this->request->getPost('action');
         $type = $this->request->getPost('type');
+        $isActionProcessed = false;
         if ($type === 'group') {
             $groupAction = $this->groupActions[$action] ?? null;
             if ($groupAction instanceof GroupAction) {
                 $ids = (array)($this->request->getPost('id') ?? []);
                 try {
                     $groupAction->exec($ids);
+                    $isActionProcessed = true;
                 }
                 catch (\Throwable $e) {
                     $this->grid->AddGroupError($e->getMessage());
@@ -664,11 +666,16 @@ class ModelGrid
                 $id = (int)$this->request->getPost('id');
                 try {
                     $singleAction->exec($id);
+                    $isActionProcessed = true;
                 }
                 catch (\Throwable $e) {
                     $this->grid->AddUpdateError($e->getMessage(), $id);
                 }
             }
+        }
+
+        if ($isActionProcessed) {
+            $this->collection = null;
         }
     }
 
@@ -678,7 +685,6 @@ class ModelGrid
     public function show()
     {
         $this->processActions();
-        $this->preparePoxyModelService();
         $this->fillHeaders();
         $this->fillGrid();
         $this->fillAdminButtons();


### PR DESCRIPTION
Исправлены баги, связанные с использованием метода getList в ModelGrid.
1. Вызов метода preparePoxyModelService вынесен из метода show в метод getList. Причина: когда мы вызываем метод getList мы никак не можем передать в него какие-либо параметры, однако в методе show вызывается prepareProxyModelService, который добавляет важные параметры сортировки и фильтры, связанные с гридом. Таким образом данные, полученные при вызове getList будут отличаться от тех, что мы получим в методе show, а кроме этого эти данные ещё и сохранятся в поле класса и будут использованы при следующем вызове getList (т.е. при выводе данных грида). Поэтому метод перенесён внутрь getList, чтобы данные полученные внутри метода show или при вызове извне не отличались друг от друга и были корректными данными грида.
2. Добавлен сброс данных после обработки действий. Данные после обработки действий могут быть изменены, однако если getList уже был вызван до этого, то будут показаны сохранённые до изменения данные. Поэтому необходимо сбросить старые данные, чтобы при выводе грида показались актуальные после обработки действий данные.