### PR TITLE
feat(userService): saveUserData method is protected now

### DIFF
--- a/install/index.php
+++ b/install/index.php
@@ -14,8 +14,8 @@ class bx_model extends CModule
 
     public function __construct()
     {
-        $this->MODULE_VERSION = "1.25.4";
-        $this->MODULE_VERSION_DATE = "2024-03-25 12:50:00";
+        $this->MODULE_VERSION = "1.25.5";
+        $this->MODULE_VERSION_DATE = "2024-05-22 15:00:00";
         $this->MODULE_NAME = "Bitrix model";
         $this->MODULE_DESCRIPTION = "";
     }

--- a/lib/services/userservice.php
+++ b/lib/services/userservice.php
@@ -151,7 +151,7 @@ class UserService extends BaseModelService implements UserServiceInterface
      * @param array $data
      * @return Result
      */
-    private function saveUserData(User $model, array $data): Result
+    protected function saveUserData(User $model, array $data): Result
     {
         $result = new Result();
         $cUser = new CUser();


### PR DESCRIPTION
В методе save реализовано сохранение строго определённых полей пользователя, если передать в модели какие-то доп. данные, то они не сохранятся. Если наследовать класс и реализовывать свой метод save, с сохранением иных данных, то вызвать saveUserData не получится, т.к. он приватный. Поэтому придётся дублировать логику метода saveUserData просто для сохранения иных полей.
Предлагаю сделать данный метод доступным для использования в дочерних классах.