### PR TITLE
Добавляется в фильтрацию возможность LOGIC OR

### DIFF
--- a/lib/traits/filterablehelper.php
+++ b/lib/traits/filterablehelper.php
@@ -28,6 +28,16 @@ trait FilterableHelper
     public function getFilter(array $params): array
     {
         $filterFields = static::getFilterFields();
-        return FilterParser::getParsedFilter($params, $filterFields);
+        $logicOrFields = static::getFilterFieldsWithOrLogic();
+        return FilterParser::getParsedFilter($params, $filterFields, $logicOrFields);
+    }
+
+    /**
+     * Массив групп свойств для фильтрации, которые надо объединять в logic or
+     * @return array[]
+     */
+    protected static function getFilterFieldsWithOrLogic(): array
+    {
+        return [];
     }
 }


### PR DESCRIPTION
Добавляется возможность в фильтрации указывать группы полей, которые должны объединяться по условию ИЛИ ("LOGIC" => "OR")
![logicOr](https://github.com/beta-eto-code/bx.model/assets/31045634/4ebc31ad-702e-4a82-8ad5-bf52f9710c47)

1) В сервисы добавляется метод getFilterFieldsWithOrLogic  в котором можно указать "группы" полей которые нужны объединить по условию ИЛИ (массив массивов). По умолчанию пустой массив и поведение не меняется.
2) В методе getParsedFilter идет проверка переданного массива. Группировка в фильтре по условию ИЛИ "групп" переданных полей.  По умолчанию пустой массив и поведение не меняется.