### PR TITLE
fix(FetcherModel): исправлен фетчер для ключей разных типов, добавлен тест на приведение значений внешних ключей

### DIFF
--- a/install/index.php
+++ b/install/index.php
@@ -14,8 +14,8 @@ class bx_model extends CModule
 
     public function __construct()
     {
-        $this->MODULE_VERSION = "1.26.2";
-        $this->MODULE_VERSION_DATE = "2024-04-03";
+        $this->MODULE_VERSION = "1.26.3";
+        $this->MODULE_VERSION_DATE = "2024-04-08";
         $this->MODULE_NAME = "Bitrix model";
         $this->MODULE_DESCRIPTION = "";
     }

--- a/tests/FetcherModelTest.php
+++ b/tests/FetcherModelTest.php
@@ -387,5 +387,52 @@ class FetcherModelTest extends TestCase
         );
 
         $fetcher->fill($collection); //не должно выдавать ошибку, должно пропустить некорректный ключ
+
+        $listWithInvalidModelIdType = [
+            [
+                'id' => 1,
+                'model_id' => '21.0000', //строка, приводимая к int
+            ],
+            [
+                'id' => 2,
+                'model_id' => 22.0000, //float, приводимый к int
+            ],
+            [
+                'id' => 3,
+                'model_id' => '23.005', //строка, приводимая к float, но не к int
+            ],
+        ];
+        $assertValueWithValidTypes = [
+            [
+                'id' => 1,
+                'model_id' => '21.0000',
+                'externalModel' => [
+                    'id' => 21,
+                    'title' => 'model 21',
+                ],
+            ],
+            [
+                'id' => 2,
+                'model_id' => 22.0000,
+                'externalModel' => [
+                    'id' => 22,
+                    'title' => 'model 22',
+                ],
+            ],
+            [
+                'id' => 3,
+                'model_id' => '23.005',
+            ],
+        ];
+        $collection = $this->initCollection($listWithInvalidModelIdType);
+        $fetcher = FetcherModel::initAsSingleValue(
+            $this->linkedService,
+            'externalModel',
+            'model_id',
+            'id'
+        );
+
+        $fetcher->fill($collection);
+        $this->assertEquals(json_encode($assertValueWithValidTypes), json_encode($collection));
     }
 }


### PR DESCRIPTION
В Битриксе для значений ID связанных элементов в некоторых случаях передаётся float (при использовании старого апи), либо строка, содержащая float. Один из примеров - превью картинок в инфоблоках.
![image](https://github.com/user-attachments/assets/4605ae03-c32e-4ddf-830d-c146254557b9)
В связи с последними правками получается ситуация, когда мы индексируем элементы с ключом '123.000', а пытаемся получить по целочисленному значению 123. В таком случае связанный элемент не найдётся. Поэтому необходим метод, который будет превращать переданное значение в валидный ключ для массива, при этом при использовании разных по типу, но приводимых к одному и тому же значению вариантов, будет выдавать один и тот же результат. Этот ключ используется исключительно внутри фетчера и не меняет исходных данных самих моделей.
Раньше это работало корректно, т.к. работало через нестрогое сравнение.
![image](https://github.com/user-attachments/assets/b38644c5-115e-4d09-b680-98d79582282e)
Доработано с учётом правок по производительности, но с сохранением старой логики.
